### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/Modules/IPy.py
+++ b/Modules/IPy.py
@@ -318,9 +318,9 @@ class IPint(object):
            (self._ipversion == 6 and self._prefixlen == 128):
             if self.NoPrefixForSingleIp:
                 want = 0
-        if want == None:
+        if want is None:
             want = self.WantPrefixLen
-            if want == None:
+            if want is None:
                 want = 1
         if want:
             if want == 2:
@@ -354,7 +354,7 @@ class IPint(object):
         """
 
         bits = _ipVersionToLen(self._ipversion)
-        if self.WantPrefixLen == None and wantprefixlen == None:
+        if self.WantPrefixLen is None and wantprefixlen is None:
             wantprefixlen = 0
         ret = _intToBin(self.ip)
         return  '0' * (bits - len(ret)) + ret + self._printPrefix(wantprefixlen)
@@ -370,7 +370,7 @@ class IPint(object):
         'ffff:ffff:ffff:ffff:ffff:f:f:fffc/127'
         """
 
-        if self.WantPrefixLen == None and wantprefixlen == None:
+        if self.WantPrefixLen is None and wantprefixlen is None:
             wantprefixlen = 1
 
         if self._ipversion == 4:
@@ -413,7 +413,7 @@ class IPint(object):
         2001:658:22a:cafe:200:0:0:1
         """
 
-        if self.WantPrefixLen == None and wantprefixlen == None:
+        if self.WantPrefixLen is None and wantprefixlen is None:
             wantprefixlen = 1
 
         if self._ipversion == 4:
@@ -436,7 +436,7 @@ class IPint(object):
         2001:0658:022a:cafe:0200:0000:0000:0001
         """
 
-        if self.WantPrefixLen == None and wantprefixlen == None:
+        if self.WantPrefixLen is None and wantprefixlen is None:
             wantprefixlen = 1
 
         return intToIp(self.ip, self._ipversion) + self._printPrefix(wantprefixlen)
@@ -450,7 +450,7 @@ class IPint(object):
         0x20010658022acafe0200000000000001
         """
 
-        if self.WantPrefixLen == None and wantprefixlen == None:
+        if self.WantPrefixLen is None and wantprefixlen is None:
             wantprefixlen = 0
 
         x = '0x%x' % self.ip
@@ -465,7 +465,7 @@ class IPint(object):
         42540616829182469433547762482097946625
         """
 
-        if self.WantPrefixLen == None and wantprefixlen == None:
+        if self.WantPrefixLen is None and wantprefixlen is None:
             wantprefixlen = 0
 
         x = '%d' % self.ip

--- a/Tools/windowsprivcheck.py
+++ b/Tools/windowsprivcheck.py
@@ -1344,7 +1344,7 @@ def check_weak_perms(object_name, object_type_s, perms):
 		else:
 			object_type_s = 'directory'
 	
-	if object_type == None:
+	if object_type is None:
 		print "ERROR: Unknown object type %s" % object_type_s
 		exit(1)
 		
@@ -1365,7 +1365,7 @@ def check_weak_write_perms_by_sd(object_name, object_type_s, sd):
 	
 def check_weak_perms_sd(object_name, object_type_s, sd, perms):
 	dacl= sd.GetSecurityDescriptorDacl()
-	if dacl == None:
+	if dacl is None:
 		print "No Discretionary ACL"
 		return []
 
@@ -1439,7 +1439,7 @@ def dump_perms(object_name, object_type_s, options={}):
 		else:
 			object_type_s = 'directory'
 	
-	if object_type == None:
+	if object_type is None:
 		print "ERROR: Unknown object type %s" % object_type_s
 		exit(1)
 		
@@ -1460,7 +1460,7 @@ def dump_sd(object_name, object_type_s, sd, options={}):
 	if not sd:
 		return 
 	dacl = sd.GetSecurityDescriptorDacl()
-	if dacl == None:
+	if dacl is None:
 		print "No Discretionary ACL"
 		return []
 
@@ -1499,7 +1499,7 @@ def dump_sd(object_name, object_type_s, sd, options={}):
 	
 def dump_acl(object_name, object_type_s, sd, options={}):
 	dacl = sd
-	if dacl == None:
+	if dacl is None:
 		print "No Discretionary ACL"
 		return []
 
@@ -3026,7 +3026,7 @@ if not (
 ):
 	usage()
 
-if report_file_name == None:
+if report_file_name is None:
 	report_file_name = "privesc-report-" + socket.gethostname() + ".html"
 
 # Better open the report file now in case there's a permissions problem


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:blindfuzzy:LHF?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:blindfuzzy:LHF?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
